### PR TITLE
Remove --symbols option and make it default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ help:
 ci-bootstrap: ci/bootstrap.py
 	python ci/bootstrap.py
 
-clean: clean-build clean-pyc clean-test ## remove all build, test, coverage and Python artifacts
+clean: clean-build clean-pyc clean-test clean-docs
 
 clean-build: ## remove build artifacts
 	rm -fr build/
@@ -52,6 +52,13 @@ clean-test: ## remove test and coverage artifacts
 	rm -f .coverage
 	rm -fr htmlcov/
 
+clean-docs: ## remove generated docs files
+	rm -rf dist/docs
+	rm -rf HELP
+	rm -rf HELP_UPDATE
+	rm -rf HELP_NEW
+	rm -rf HELP_CHECK
+
 lint: ## check style with flake8
 	flake8 src/smap tests
 
@@ -68,7 +75,21 @@ coverage: ## check code coverage quickly with the default Python
 	coverage html
 	$(BROWSER) htmlcov/index.html
 
-docs: ## generate Sphinx HTML documentation, including API docs
+usage: ## generate usage content by calling the program
+	echo 'Running  ``$ smap -h`` will give::' > HELP
+	echo >> HELP
+	smap -h | sed -e 's/^/  /' >> HELP
+	echo 'Running ``$ smap update -h`` will give::' > HELP_UPDATE
+	echo >> HELP_UPDATE
+	smap update -h | sed -e 's/^/  /' >> HELP_UPDATE
+	echo 'Running ``$ smap new -h`` will give::' > HELP_NEW
+	echo >> HELP_NEW
+	smap new -h | sed -e 's/^/  /' >> HELP_NEW
+	echo 'Running ``$ smap check -h`` will give::' > HELP_CHECK
+	echo >> HELP_CHECK
+	smap check -h | sed -e 's/^/  /' >> HELP_CHECK
+
+docs: usage ## generate Sphinx HTML documentation, including API docs
 	sphinx-build -E -b doctest docs dist/docs
 	sphinx-build -E -b html docs dist/docs
 	sphinx-build -b linkcheck docs dist/docs

--- a/USAGE.rst
+++ b/USAGE.rst
@@ -23,15 +23,15 @@ tl;dr
 -----
 ::
 
-  $ smap update -s lib_example.map < symbols_list
+  $ smap update lib_example.map < symbols_list
 
 or (setting an output)::
 
-  $ smap update -s lib_example.map -o new.map < symbols_list
+  $ smap update lib_example.map -o new.map < symbols_list
 
 or::
 
-  $ cat symbols_list | smap update -s lib_example.map -o new.map
+  $ cat symbols_list | smap update lib_example.map -o new.map
 
 or (to create a new map)::
 

--- a/USAGE.rst
+++ b/USAGE.rst
@@ -44,110 +44,16 @@ or (to check the content of a existing map)::
 Long version
 ------------
 
-Running  ``$ smap -h`` will give::
-
-  usage: smap [-h] {update,new,check} ...
-
-  Helper tools for linker version script maintenance
-
-  optional arguments:
-    -h, --help          show this help message and exit
-
-  Subcommands:
-    {update,new,check}  These subcommands have their own set of options
-      update            Update the map file
-      new               Create a new map file
-      check             Check the map file
+.. include:: ../HELP
 
 Call a subcommand passing '-h' to see its specific options
 There are three subcommands, ``update``, ``new``, and ``check``
-Running ``$ smap update -h`` will give::
 
-  usage: smap update [-h] [-o OUT] [-i INPUT] [-d]
-                     [--verbosity {quiet,error,warning,info,debug} | --quiet | --debug]
-                     [-l LOGFILE] [-n NAME] [-v VERSION] [-r RELEASE]
-                     [--no_guess] [--allow-abi-break] (-a | --remove | -s)
-                     file
+.. include:: ../HELP_UPDATE
 
-  positional arguments:
-    file                  The map file being updated
+.. include:: ../HELP_NEW
 
-  optional arguments:
-    -h, --help            show this help message and exit
-    -o OUT, --out OUT     Output file (defaults to stdout)
-    -i INPUT, --in INPUT  Read from this file instead of stdio
-    -d, --dry             Do everything, but do not modify the files
-    --verbosity {quiet,error,warning,info,debug}
-                          Set the program verbosity
-    --quiet               Makes the program quiet
-    --debug               Makes the program print debug info
-    -l LOGFILE, --logfile LOGFILE
-                          Log to this file
-    -n NAME, --name NAME  The name of the library (e.g. libx)
-    -v VERSION, --version VERSION
-                          The release version (e.g. 1_0_0 or 1.0.0)
-    -r RELEASE, --release RELEASE
-                          The full name of the release to be used (e.g.
-                          LIBX_1_0_0)
-    --no_guess            Disable next release name guessing
-    --allow-abi-break     Allow removing symbols, and to break ABI
-    -a, --add             Adds the symbols to the map file.
-    --remove              Remove the symbols from the map file. This breaks the
-                          ABI.
-    -s, --symbols         Compare the given symbol list with the current map
-                          file and update accordingly. May break the ABI.
-
-  A list of symbols is expected as the input. If a file is provided with '-i',
-  the symbols are read from the given file. Otherwise the symbols are read from
-  stdin.
-
-Running  ``$ smap new -h`` will give::
-
-  usage: smap new [-h] [-o OUT] [-i INPUT] [-d]
-                  [--verbosity {quiet,error,warning,info,debug} | --quiet | --debug]
-                  [-l LOGFILE] [-n NAME] [-v VERSION] [-r RELEASE] [--no_guess]
-
-  optional arguments:
-    -h, --help            show this help message and exit
-    -o OUT, --out OUT     Output file (defaults to stdout)
-    -i INPUT, --in INPUT  Read from this file instead of stdio
-    -d, --dry             Do everything, but do not modify the files
-    --verbosity {quiet,error,warning,info,debug}
-                          Set the program verbosity
-    --quiet               Makes the program quiet
-    --debug               Makes the program print debug info
-    -l LOGFILE, --logfile LOGFILE
-                          Log to this file
-    -n NAME, --name NAME  The name of the library (e.g. libx)
-    -v VERSION, --version VERSION
-                          The release version (e.g. 1_0_0 or 1.0.0)
-    -r RELEASE, --release RELEASE
-                          The full name of the release to be used (e.g.
-                          LIBX_1_0_0)
-    --no_guess            Disable next release name guessing
-
-  A list of symbols is expectedas the input. If a file is provided with '-i',
-  the symbols are read from the given file. Otherwise the symbols are read from
-  stdin.
-
-Running  ``$ smap check -h`` will give::
-
-  usage: smap check [-h]
-                    [--verbosity {quiet,error,warning,info,debug} | --quiet | --debug]
-                    [-l LOGFILE]
-                    file
-
-  positional arguments:
-    file                  The map file to be checked
-
-  optional arguments:
-    -h, --help            show this help message and exit
-    --verbosity {quiet,error,warning,info,debug}
-                          Set the program verbosity
-    --quiet               Makes the program quiet
-    --debug               Makes the program print debug info
-    -l LOGFILE, --logfile LOGFILE
-                          Log to this file
+.. include:: ../HELP_CHECK
 
 Import as a library:
 --------------------

--- a/src/smap/symver.py
+++ b/src/smap/symver.py
@@ -1087,11 +1087,11 @@ def update(args):
           unified in a new release. This is an incompatible change, the SONAME
           of the library should be bumped
 
-    If --symbols is provided, the symbols provided are considered all the
-    exported symbols in the new version. Such set of symbols is compared to the
-    previous existing symbols. If symbols are added, but nothing removed, it is
-    a compatible change. Otherwise, it is an incompatible change and the SONAME
-    of the library should be bumped.
+    The symbols provided are considered all the exported symbols in the
+    new version. Such set of symbols is compared to the previous existing
+    symbols. If symbols are added, but nothing removed, it is a compatible
+    change. Otherwise, it is an incompatible change and the SONAME of the
+    library should be bumped.
 
     If --add is provided, the symbols provided are considered new symbols to be
     added. This is a compatible change.
@@ -1160,17 +1160,8 @@ def update(args):
     added = []
     removed = []
 
-    # If the list of all symbols are being compared
-    if args.symbols:
-        for symbol in new_set:
-            if symbol not in all_symbols:
-                added.append(symbol)
-
-        for symbol in all_symbols:
-            if symbol not in new_set:
-                removed.append(symbol)
     # If the list of symbols are being added
-    elif args.add:
+    if args.add:
         # Check the symbols and print a warning if already present
         for symbol in new_symbols:
             if symbol in all_symbols:
@@ -1192,6 +1183,15 @@ def update(args):
                                " not found."])
                 logger.warn(msg)
                 # warnings.warn(msg)
+    # If the list of all symbols are being compared (the default option)
+    else:
+        for symbol in new_set:
+            if symbol not in all_symbols:
+                added.append(symbol)
+
+        for symbol in all_symbols:
+            if symbol not in new_set:
+                removed.append(symbol)
 
     # Remove duplicates
     added = list(set(added))
@@ -1511,15 +1511,11 @@ def get_arg_parser():
     parser_up.add_argument("--allow-abi-break",
                            help="Allow removing symbols, and to break ABI",
                            action='store_true')
-    group = parser_up.add_mutually_exclusive_group(required=True)
+    group = parser_up.add_mutually_exclusive_group()
     group.add_argument("-a", "--add", help="Adds the symbols to the map file.",
                        action='store_true')
     group.add_argument("--remove", help="Remove the symbols from the map"
                        " file. This breaks the ABI.", action="store_true")
-    group.add_argument("-s", "--symbols",
-                       help="Compare the given symbol list with the current"
-                       " map file and update accordingly. May break the ABI.",
-                       action='store_true')
     parser_up.add_argument('file', help='The map file being updated')
     parser_up.set_defaults(func=update)
 

--- a/src/smap/symver.py
+++ b/src/smap/symver.py
@@ -1525,7 +1525,7 @@ def get_arg_parser():
                                        parents=[file_args, verb_args,
                                                 name_args],
                                        epilog="A list of symbols is expected"
-                                       "as the input.\nIf a file is provided"
+                                       " as the input.\nIf a file is provided"
                                        " with \'-i\', the symbols are read"
                                        " from the given file. Otherwise the"
                                        " symbols are read from stdin.")

--- a/tests/data/test_script/options.yaml
+++ b/tests/data/test_script/options.yaml
@@ -27,7 +27,6 @@
   input:
     args:
       - "update"
-      - "--symbols"
       - "--allow-abi-break"
       - "base.map"
     stdin: "symbol.in"

--- a/tests/data/test_update/broken_maps.yaml
+++ b/tests/data/test_update/broken_maps.yaml
@@ -3,7 +3,6 @@
   input:
     args:
       - "update"
-      - "--symbols"
       - "--out"
       - "nameless.out"
       - "nameless.map"
@@ -18,7 +17,6 @@
   input:
     args:
       - "update"
-      - "--symbols"
       - "--allow-abi-break"
       - "--out"
       - "duplicated.out"
@@ -35,7 +33,6 @@
   input:
     args:
       - "update"
-      - "--symbols"
       - "--out"
       - "opening.out"
       - "opening.map"
@@ -50,7 +47,6 @@
   input:
     args:
       - "update"
-      - "--symbols"
       - "--out"
       - "invalid_element.out"
       - "invalid_element.map"
@@ -65,7 +61,6 @@
   input:
     args:
       - "update"
-      - "--symbols"
       - "--out"
       - "missing_semicolon.out"
       - "missing_semicolon.map"
@@ -80,7 +75,6 @@
   input:
     args:
       - "update"
-      - "--symbols"
       - "--allow-abi-break"
       - "--out"
       - "missing_visibility.out"
@@ -98,7 +92,6 @@
   input:
     args:
       - "update"
-      - "--symbols"
       - "--out"
       - "invalid_previous.out"
       - "invalid_previous.map"
@@ -113,7 +106,6 @@
   input:
     args:
       - "update"
-      - "--symbols"
       - "--out"
       - "missing_previous_closer.out"
       - "missing_previous_closer.map"
@@ -128,7 +120,6 @@
   input:
     args:
       - "update"
-      - "--symbols"
       - "--out"
       - "non_existing_previous.out"
       - "non_existing_previous.map"
@@ -143,7 +134,6 @@
   input:
     args:
       - "update"
-      - "--symbols"
       - "--out"
       - "duplicated_dependency.out"
       - "duplicated_dependency.map"
@@ -159,7 +149,6 @@
   input:
     args:
       - "update"
-      - "--symbols"
       - "--out"
       - "circular_dependency.out"
       - "circular_dependency.map"
@@ -174,7 +163,6 @@
   input:
     args:
       - "update"
-      - "--symbols"
       - "--allow-abi-break"
       - "--out"
       - "wildcard_warnings.out"
@@ -206,7 +194,6 @@
   input:
     args:
       - "update"
-      - "--symbols"
       - "--allow-abi-break"
       - "--out"
       - "baseless.out"

--- a/tests/data/test_update/logfile.yaml
+++ b/tests/data/test_update/logfile.yaml
@@ -3,7 +3,6 @@
   input:
     args:
       - "update"
-      - "--symbols"
       - "--logfile"
       - "wildcard_warnings.log"
       - "--out"

--- a/tests/data/test_update/overwrite.yaml
+++ b/tests/data/test_update/overwrite.yaml
@@ -3,7 +3,6 @@
   input:
     args:
       - "update"
-      - "--symbols"
       - "--allow-abi-break"
       - "--out"
       - "overwrite.map"

--- a/tests/data/test_update/symbols.yaml
+++ b/tests/data/test_update/symbols.yaml
@@ -3,7 +3,6 @@
   input:
     args:
       - "update"
-      - "--symbols"
       - "--out"
       - "symbols.map"
       - "symbols.map"

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,8 @@ envlist =
     docs
 
 [testenv]
+whitelist_externals =
+    make
 basepython =
     {docs,spell}: {env:TOXPYTHON:python2.7}
     {bootstrap,clean,check,report,extension-coveralls,coveralls,codecov}: {env:TOXPYTHON:python3}
@@ -49,6 +51,7 @@ deps =
 deps =
     -r{toxinidir}/docs/requirements.txt
 commands =
+    make usage
     sphinx-build {posargs:-E} -b doctest docs dist/docs
     sphinx-build {posargs:-E} -b html docs dist/docs
     sphinx-build -b linkcheck docs dist/docs


### PR DESCRIPTION
This make '--symbols' default for the 'update' command.  This way the
strategy option is no longer required and will be assumed as the
same as the current '--symbols'.  This means if '--add' and '--remove'
are not provided, the provided symbols will be compared with the
existing symbols to create the set of added and removed symbols.

Also automatically generates usage description documentation.