### PR TITLE
Fixed a bug in the release name generation

### DIFF
--- a/src/smap/symver.py
+++ b/src/smap/symver.py
@@ -902,6 +902,9 @@ def get_info_from_release_string(release):
         # The prefix can have trailing '_'
         prefix = prefix.rstrip("_")
 
+    # Fix common unsupported characters in prefix
+    prefix = prefix.replace("-", "_")
+
     # Return the information got
     return [release, prefix, ver_suffix, version]
 

--- a/tests/data_template/test_get_info_from_release_string/testcases.yaml
+++ b/tests/data_template/test_get_info_from_release_string/testcases.yaml
@@ -110,3 +110,15 @@
   warnings:
     - "No release provided"
   exceptions:
+-
+  input: "lib-x_1_0_0"
+  output:
+    - "lib-x_1_0_0"
+    - "lib_x"
+    - "_1_0_0"
+    -
+        - 1
+        - 0
+        - 0
+  warnings:
+  exceptions:


### PR DESCRIPTION
Prefixes containing "-" should not be accepted.  Added a fix to replace
the invalid "-" character for a valid "_" character.