### PR TITLE
Fixed bugs in updates with release info

### DIFF
--- a/src/smap/symver.py
+++ b/src/smap/symver.py
@@ -906,7 +906,7 @@ def get_info_from_release_string(release):
     prefix = prefix.replace("-", "_")
 
     # Return the information got
-    return [release, prefix, ver_suffix, version]
+    return [release.upper(), prefix.upper(), ver_suffix, version]
 
 
 # TODO: Make bump strategy customizable
@@ -1202,16 +1202,17 @@ def update(args):
 
     if added:
         if release_info:
-            for to_up in (rs for rs in cur_map.releases if rs and rs.name ==
-                          release_info[0]):
-                # If the release to be modified is released
-                if to_up.released:
-                    msg = "Released releases cannot be modified. Abort."
-                    logger.error(msg)
-                    raise Exception(msg)
+            for to_up in cur_map.releases:
+                if to_up and to_up.name == release_info[0]:
+                    # If the release to be modified is released
+                    if to_up.released:
+                        msg = "Released releases cannot be modified. Abort."
+                        logger.error(msg)
+                        raise Exception(msg)
 
-                r = to_up
-        else:
+                    r = to_up
+
+        if not r:
             r = Release()
             # Guess the name for the new release
             r.name = cur_map.guess_name(release_info, guess=args.guess)

--- a/tests/data_template/test_get_info_from_release_string/testcases.yaml
+++ b/tests/data_template/test_get_info_from_release_string/testcases.yaml
@@ -3,8 +3,8 @@
 -
   input: "libx_1_0_0"
   output:
-    - "libx_1_0_0"
-    - "libx"
+    - "LIBX_1_0_0"
+    - "LIBX"
     - "_1_0_0"
     -
       - 1
@@ -15,8 +15,8 @@
 -
   input: "libx_____1____0____0___"
   output:
-    - "libx_____1____0____0___"
-    - "libx"
+    - "LIBX_____1____0____0___"
+    - "LIBX"
     - "_1_0_0"
     -
       - 1
@@ -27,8 +27,8 @@
 -
   input: "libx_1.0.0"
   output:
-    - "libx_1.0.0"
-    - "libx"
+    - "LIBX_1.0.0"
+    - "LIBX"
     - "_1_0_0"
     -
       - 1
@@ -39,8 +39,8 @@
 -
   input: "libx_1_0_0_1_0_0"
   output:
-    - "libx_1_0_0_1_0_0"
-    - "libx"
+    - "LIBX_1_0_0_1_0_0"
+    - "LIBX"
     - "_1_0_0_1_0_0"
     -
       - 1
@@ -54,8 +54,8 @@
 -
   input: "libx_______"
   output:
-    - "libx_______"
-    - "libx"
+    - "LIBX_______"
+    - "LIBX"
     -
     -
         -
@@ -66,8 +66,8 @@
 -
   input: "libx_1_"
   output:
-    - "libx_1_"
-    - "libx"
+    - "LIBX_1_"
+    - "LIBX"
     - "_1"
     -
       - 1
@@ -76,8 +76,8 @@
 -
   input: "lib1_1_0"
   output:
-    - "lib1_1_0"
-    - "lib1"
+    - "LIB1_1_0"
+    - "LIB1"
     - "_1_0"
     -
       - 1
@@ -87,8 +87,8 @@
 -
   input: "libx"
   output:
-    - "libx"
-    - "libx"
+    - "LIBX"
+    - "LIBX"
     -
     -
         -
@@ -113,8 +113,8 @@
 -
   input: "lib-x_1_0_0"
   output:
-    - "lib-x_1_0_0"
-    - "lib_x"
+    - "LIB-X_1_0_0"
+    - "LIB_X"
     - "_1_0_0"
     -
         - 1

--- a/tests/data_template/test_update/symbols.yaml
+++ b/tests/data_template/test_update/symbols.yaml
@@ -65,3 +65,30 @@
     warnings:
     exceptions:
       - "Released releases cannot be modified. Abort."
+-
+  input:
+    args:
+      - "update"
+      - "-r"
+      - "WITH_RELEASE_INFO_1_0_0"
+      - "base.map"
+    stdin: "with_release_info.in"
+  output:
+    file:
+    stdout: "with_release_info.stdout"
+    warnings:
+    exceptions:
+-
+  input:
+    args:
+      - "update"
+      - "-r"
+      - "WITH_RELEASE_INFO_1_0_0"
+      - "--allow-abi-break"
+      - "base.map"
+    stdin: "symbol.in"
+  output:
+    file:
+    stdout: "with_release_abi_break.stdout"
+    warnings:
+    exceptions:

--- a/tests/data_template/test_update/with_release_abi_break.stdout
+++ b/tests/data_template/test_update/with_release_abi_break.stdout
@@ -1,0 +1,17 @@
+Added:
+    symbol
+
+Removed:
+    one_symbol
+
+Merging all symbols in a single new release
+# This map file was updated with PROGRAM_NAME_VERSION
+
+WITH_RELEASE_INFO_1_0_0
+{
+    global:
+        symbol;
+    local:
+        *;
+} ;
+

--- a/tests/data_template/test_update/with_release_info.in
+++ b/tests/data_template/test_update/with_release_info.in
@@ -1,0 +1,2 @@
+symbol
+one_symbol

--- a/tests/data_template/test_update/with_release_info.stdout
+++ b/tests/data_template/test_update/with_release_info.stdout
@@ -1,0 +1,19 @@
+Added:
+    symbol
+
+# This map file was updated with PROGRAM_NAME_VERSION
+
+WITH_RELEASE_INFO_1_0_0
+{
+    global:
+        symbol;
+} BASE_1_0_0;
+
+BASE_1_0_0
+{
+    global:
+        one_symbol;
+    local:
+        *;
+} ;
+


### PR DESCRIPTION
When release information were provided (using "-r"), updates which added
symbols but not removed were failing because the element used to point
to the release to be modified was obtained in a generator, which ceases
to exist in the end of the for loop.  Changing the loop to iterate over
the actual elements of the releases list solved this bug.

The strings in the result of get_info_from_release_string() were not
being converted to upper case.  This was leading to errors when
searching for releases to be updated when release info is provided.