### PR TITLE
tests: check pytest version and skip if < 3.4

### DIFF
--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -68,6 +68,7 @@ def run_tc(tc, datadir, capsys, caplog):
         caplog.clear()
 
 
+@pytest.mark.skipif(pytest.__version__ < '3.4', reason="caplog not supported")
 def test_check(testcases, datadir, capsys, caplog):
     for tc in testcases:
         run_tc(tc, datadir, capsys, caplog)

--- a/tests/test_check_files.py
+++ b/tests/test_check_files.py
@@ -5,6 +5,8 @@
 import filecmp
 import os
 
+import pytest
+
 from smap import symver
 
 
@@ -30,6 +32,7 @@ def test_different_overwrite(datadir):
                        "--in", str(in_name), True)
 
 
+@pytest.mark.skipif(pytest.__version__ < '3.4', reason="caplog not supported")
 def test_same_file(datadir, caplog):
 
     in_name = os.path.join(str(datadir), "in.map")

--- a/tests/test_get_info_from_release_string.py
+++ b/tests/test_get_info_from_release_string.py
@@ -7,6 +7,7 @@ import pytest
 from smap import symver
 
 
+@pytest.mark.skipif(pytest.__version__ < '3.4', reason="caplog not supported")
 def test_get_info_from_release_string(testcases, caplog):
     if testcases:
         for tc in testcases:

--- a/tests/test_get_version_from_string.py
+++ b/tests/test_get_version_from_string.py
@@ -5,6 +5,7 @@ import pytest
 from smap import symver
 
 
+@pytest.mark.skipif(pytest.__version__ < '3.4', reason="caplog not supported")
 def test_get_version_from_string(testcases, caplog):
     if testcases:
         for tc in testcases:

--- a/tests/test_new.py
+++ b/tests/test_new.py
@@ -2,9 +2,11 @@
 
 """Tests for new command"""
 
+import pytest
 from conftest import run_tc
 
 
+@pytest.mark.skipif(pytest.__version__ < '3.4', reason="caplog not supported")
 def test_new(testcases, datadir, capsys, caplog):
     for tc in testcases:
         run_tc(tc, datadir, capsys, caplog)

--- a/tests/test_overwrite_protected.py
+++ b/tests/test_overwrite_protected.py
@@ -5,10 +5,12 @@ from stat import S_IRGRP
 from stat import S_IROTH
 from stat import S_IRUSR
 
+import pytest
 from conftest import run_tc
 
 
 # Special case that need setup first
+@pytest.mark.skipif(pytest.__version__ < '3.4', reason="caplog not supported")
 def test_overwrite_protected(testcases, datadir, capsys, caplog):
 
     protected = os.path.join(str(datadir), "overwrite_protected.in.old")

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -2,9 +2,11 @@
 
 """Tests for update command"""
 
+import pytest
 from conftest import run_tc
 
 
+@pytest.mark.skipif(pytest.__version__ < '3.4', reason="caplog not supported")
 def test_update(testcases, datadir, capsys, caplog):
     for tc in testcases:
         run_tc(tc, datadir, capsys, caplog)


### PR DESCRIPTION
Some tests use the caplog fixture, which is available in pytest since
version 3.4.